### PR TITLE
Fix Google redirect cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # PEP 621-compliant metadata
 [project]
 name = "article-degoogler"
-version = "0.1.1"
+version = "0.1.2"
 description = "Clean up exported web content to remove Google-injected link decorations"
 authors = [{ name = "Dave Thomas", email = "davidcthomas@gmail.com" }]
 license = { text = "MIT" }
@@ -12,7 +12,7 @@ requires-python = ">=3.12,<3.13"
 dependencies = []
 
 [project.scripts]
-fix-links = "article_degoogler.fix_links:main"
+fix-links = "article_degoogler.article_degoogler:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/article_degoogler/__init__.py
+++ b/src/article_degoogler/__init__.py
@@ -2,6 +2,6 @@
 
 __all__ = ["clean_href", "process_html", "process_file", "main", "__version__"]
 
-from .fix_links import clean_href, process_html, process_file, main
+from .article_degoogler import clean_href, process_html, process_file, main
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/src/article_degoogler/article_degoogler.py
+++ b/src/article_degoogler/article_degoogler.py
@@ -4,13 +4,16 @@ import sys
 
 
 def clean_href(url: str) -> str:
-    """Remove Google redirect prefix and '/&amp;sa' query from a URL."""
+    """Remove Google redirect prefix and trailing ``&sa=`` parameters."""
     prefix = "https://www.google.com/url?q="
     if url.startswith(prefix):
         url = url[len(prefix):]
-    cut_pos = url.find('/&amp;sa')
-    if cut_pos != -1:
-        url = url[:cut_pos]
+
+    # Strip ``&sa=`` query parameters which Google adds for tracking.  These
+    # may appear with either a literal ampersand or the HTML encoded
+    # ``&amp;`` variant.  Everything from the ``&`` through the end of the
+    # string should be discarded when found.
+    url = re.sub(r"&(amp;)?sa=.*", "", url, flags=re.IGNORECASE)
     return url
 
 


### PR DESCRIPTION
## Summary
- update `clean_href` to strip trailing &sa params
- fix package import after file rename
- bump version to 0.1.2
- update entrypoint module

## Testing
- `python3 -m compileall -q src`
- `PYENV_VERSION=3.12.10 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544a356d8c8320b55fbe00b0879f16